### PR TITLE
Add optional format argument for JPG output

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ All the modified files are in the [optimizedSD](optimizedSD) folder, so if you h
 
 - Mixed Precision is enabled by default. If you don't have a GPU with tensor cores (any GTX 10 series card), you may not be able use mixed precision. Use the `--precision full` argument to disable it.
 
+## `--format png` or `--format jpg`
+
+**Output image format**
+
+- The default output format is `png`. While `png` is lossless, it takes up a lot of space (unless large portions of the image happen to be a single colour). Use lossy `jpg` to get smaller image file sizes.
+
 ## `--unet_bs`
 
 **Batch size for the unet model**

--- a/optimizedSD/optimized_img2img.py
+++ b/optimizedSD/optimized_img2img.py
@@ -160,6 +160,13 @@ parser.add_argument(
 parser.add_argument(
     "--precision", type=str, help="evaluate at this precision", choices=["full", "autocast"], default="autocast"
 )
+parser.add_argument(
+    "--format",
+    type=str,
+    help="output image format",
+    choices=["jpg", "png"],
+    default="png",
+)
 opt = parser.parse_args()
 
 tic = time.time()
@@ -315,7 +322,7 @@ with torch.no_grad():
                     x_sample = torch.clamp((x_samples_ddim + 1.0) / 2.0, min=0.0, max=1.0)
                     x_sample = 255.0 * rearrange(x_sample[0].cpu().numpy(), "c h w -> h w c")
                     Image.fromarray(x_sample.astype(np.uint8)).save(
-                        os.path.join(sample_path, "seed_" + str(opt.seed) + "_" + f"{base_count:05}.png")
+                        os.path.join(sample_path, "seed_" + str(opt.seed) + "_" + f"{base_count:05}.{opt.format}")
                     )
                     seeds += str(opt.seed) + ","
                     opt.seed += 1

--- a/optimizedSD/optimized_txt2img.py
+++ b/optimizedSD/optimized_txt2img.py
@@ -149,6 +149,13 @@ parser.add_argument(
 parser.add_argument(
     "--precision", type=str, help="evaluate at this precision", choices=["full", "autocast"], default="autocast"
 )
+parser.add_argument(
+    "--format",
+    type=str,
+    help="output image format",
+    choices=["jpg", "png"],
+    default="png",
+)
 opt = parser.parse_args()
 
 tic = time.time()
@@ -288,7 +295,7 @@ with torch.no_grad():
                     x_sample = torch.clamp((x_samples_ddim + 1.0) / 2.0, min=0.0, max=1.0)
                     x_sample = 255.0 * rearrange(x_sample[0].cpu().numpy(), "c h w -> h w c")
                     Image.fromarray(x_sample.astype(np.uint8)).save(
-                        os.path.join(sample_path, "seed_" + str(opt.seed) + "_" + f"{base_count:05}.png")
+                        os.path.join(sample_path, "seed_" + str(opt.seed) + "_" + f"{base_count:05}.{opt.format}")
                     )
                     seeds += str(opt.seed) + ","
                     opt.seed += 1


### PR DESCRIPTION
Adds the optional argument `--format` with choices `png` (default) and `jpg`.
JPG is a better format for photo-realistic output
if one is willing to forgo losslessness for smaller file sizes.