### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*Dockerfile*
+docker-compose.yml
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM nvidia/cuda:11.3.1-base-ubuntu20.04
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt update \
+ && apt install --no-install-recommends -y curl wget git \
+ && apt-get clean
+
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-py38_4.12.0-Linux-x86_64.sh -O ~/miniconda.sh \
+ && bash ~/miniconda.sh -b -p $HOME/miniconda \
+ && $HOME/miniconda/bin/conda init
+
+COPY . /root/stable-diffusion
+
+RUN eval "$($HOME/miniconda/bin/conda shell.bash hook)" \
+ && cd /root/stable-diffusion \
+ && conda env create -f environment.yaml \
+ && conda activate ldm \
+ && pip install gradio==3.1.7
+
+VOLUME /root/.cache
+VOLUME /data
+VOLUME /output
+
+ENV PYTHONUNBUFFERED=1
+ENV GRADIO_SERVER_NAME=0.0.0.0
+ENV GRADIO_SERVER_PORT=7860
+EXPOSE 7860
+
+RUN ln -s /data /root/stable-diffusion/models/ldm/stable-diffusion-v1 \
+ && mkdir -p /output /root/stable-diffusion/outputs \
+ && ln -s /output /root/stable-diffusion/outputs/txt2img-samples
+
+WORKDIR /root/stable-diffusion
+
+ENTRYPOINT ["/root/stable-diffusion/docker-bootstrap.sh"]
+CMD python optimizedSD/txt2img_gradio.py

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ To achieve this, the stable diffusion model is fragmented into four parts which 
 
 All the modified files are in the [optimizedSD](optimizedSD) folder, so if you have already cloned the original repository you can just download and copy this folder into the original instead of cloning the entire repo. You can also clone this repo and follow the same installation steps as the original (mainly creating the conda environment and placing the weights at the specified location).
 
+Alternatively, if you prefer to use Docker, you can do the following:
+1. Install [Docker](https://docs.docker.com/engine/install/), [Docker Compose plugin](https://docs.docker.com/compose/install/), and [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
+2. Clone this repo to, e.g., `~/stable-diffusion`
+3. Put your downloaded `model.ckpt` file into `~/sd-data` (it's a relative path, you can change it in `docker-compose.yml`)
+4. `cd` into `~/stable-diffusion` and execute `docker compose up --build`
+
+This will launch gradio on port 7860 with txt2img. You can also use `docker compose run` to execute other Python scripts.
+
 <h1 align="center">Usage</h1>
 
 ## img2img

--- a/docker-bootstrap.sh
+++ b/docker-bootstrap.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+eval "$($HOME/miniconda/bin/conda shell.bash hook)"
+conda activate ldm
+exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+services:
+  sd:
+    build: .
+    ports:
+      - "7860:7860"
+    volumes:
+      - ../sd-data:/data
+      - ../sd-output:/output
+      - sd-cache:/root/.cache
+    runtime: nvidia
+volumes:
+  sd-cache:


### PR DESCRIPTION
Hello!

Apologies for creating this PR out of the blue, but I thought it might be useful to have the option to run SD in a containerized environment. This will allow SD usage without having to deal directly with conda or other prerequisites, as long as Docker is installed with the NVIDIA Container Toolkit, as described in the changed README file.

Internally, the Dockerfile still uses conda, so any updates to the environment.yaml file should continue to work.

Thanks!