### PR TITLE
Fix #111: add helpful generation metadata

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -24,7 +24,7 @@ dependencies:
     - transformers==4.19.2
     - torchmetrics==0.6.0
     - kornia==0.6
-    - py3exiv2==0.11.0
+    - -e https://github.com/sowbug/tinyxmp/tarball/master
     - -e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
     - -e git+https://github.com/openai/CLIP.git@main#egg=clip
     - -e .

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,6 +24,7 @@ dependencies:
     - transformers==4.19.2
     - torchmetrics==0.6.0
     - kornia==0.6
+    - python-xmp-toolkit==2.0.1
     - -e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
     - -e git+https://github.com/openai/CLIP.git@main#egg=clip
     - -e .

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,7 +24,7 @@ dependencies:
     - transformers==4.19.2
     - torchmetrics==0.6.0
     - kornia==0.6
-    - python-xmp-toolkit==2.0.1
+    - pyexiv2==2.8.0
     - -e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
     - -e git+https://github.com/openai/CLIP.git@main#egg=clip
     - -e .

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,7 +24,7 @@ dependencies:
     - transformers==4.19.2
     - torchmetrics==0.6.0
     - kornia==0.6
-    - pyexiv2==2.8.0
+    - py3exiv2==0.11.0
     - -e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
     - -e git+https://github.com/openai/CLIP.git@main#egg=clip
     - -e .

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,7 +24,7 @@ dependencies:
     - transformers==4.19.2
     - torchmetrics==0.6.0
     - kornia==0.6
-    - -e https://github.com/sowbug/tinyxmp/tarball/master
+    - -e git+https://github.com/sowbug/tinyxmp.git@master#egg=tinyxmp
     - -e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
     - -e git+https://github.com/openai/CLIP.git@main#egg=clip
     - -e .

--- a/optimizedSD/optimized_txt2img.py
+++ b/optimizedSD/optimized_txt2img.py
@@ -48,8 +48,11 @@ def add_metadata(filename, opt):
         safe_opts[k] = v
     metadata = json.dumps(safe_opts)
 
-    img = pyexiv2.Image(filename)
-    img.modify_xmp({'Xmp.dc.description': metadata})
+    img_md = pyexiv2.ImageMetadata(filename)
+    img_md.read()
+    key = 'Xmp.dc.description'
+    img_md[key] = pyexiv2.XmpTag(key, metadata)
+    img_md.write()
 
 
 config = "optimizedSD/v1-inference.yaml"

--- a/optimizedSD/optimized_txt2img.py
+++ b/optimizedSD/optimized_txt2img.py
@@ -16,6 +16,7 @@ from ldm.util import instantiate_from_config
 from optimUtils import split_weighted_subprompts, logger
 from transformers import logging
 from libxmp import XMPFiles, consts, XMPMeta  # apt install exempi; pip install python-xmp-toolkit
+import json
 
 # from samplers import CompVisDenoiser
 logging.set_verbosity_error()
@@ -39,7 +40,13 @@ def add_metadata(filename, opt):
     if opt.skip_metadata:
         return
 
-    metadata = str(opt)
+    SKIP_OPT_KEYS = ['outdir']
+    safe_opts = {}
+    for k, v in vars(opt).items():
+        if k in SKIP_OPT_KEYS:
+            continue
+        safe_opts[k] = v
+    metadata = json.dumps(safe_opts)
 
     xmpfile = XMPFiles(file_path=filename, open_forupdate=True)
     xmp = xmpfile.get_xmp()

--- a/optimizedSD/optimized_txt2img.py
+++ b/optimizedSD/optimized_txt2img.py
@@ -15,7 +15,7 @@ from contextlib import contextmanager, nullcontext
 from ldm.util import instantiate_from_config
 from optimUtils import split_weighted_subprompts, logger
 from transformers import logging
-from libxmp import XMPFiles, consts, XMPMeta  # apt install exempi; pip install python-xmp-toolkit
+import pyexiv2
 import json
 
 # from samplers import CompVisDenoiser
@@ -48,14 +48,8 @@ def add_metadata(filename, opt):
         safe_opts[k] = v
     metadata = json.dumps(safe_opts)
 
-    xmpfile = XMPFiles(file_path=filename, open_forupdate=True)
-    xmp = xmpfile.get_xmp()
-    if xmp is None:
-        xmp = XMPMeta()
-    xmp.append_array_item(consts.XMP_NS_DC, 'description', metadata,
-        {'prop_array_is_ordered':True, 'prop_value_is_array':True})
-    xmpfile.put_xmp(xmp)
-    xmpfile.close_file()
+    img = pyexiv2.Image(filename)
+    img.modify_xmp({'Xmp.dc.description': metadata})
 
 
 config = "optimizedSD/v1-inference.yaml"

--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -251,8 +251,7 @@ def main():
                         if not opt.skip_save:
                             for x_sample in x_samples_ddim:
                                 x_sample = 255. * rearrange(x_sample.cpu().numpy(), 'c h w -> h w c')
-                                Image.fromarray(x_sample.astype(np.uint8)).save(
-                                    os.path.join(sample_path, f"{base_count:05}.png"))
+                                Image.fromarray(x_sample.astype(np.uint8)).save(os.path.join(sample_path, f"{base_count:05}.png"))
                                 base_count += 1
 
                         if not opt.skip_grid:


### PR DESCRIPTION
Fixes #111. EXIF wasn't exactly the right scheme; rather, XMP is recognized across both PNG and JPEG. An open issue is that https://github.com/commonsmachinery/tinyxmp is currently buggy (which is why I'm using my own fork), and it doesn't have a pip installer (there's an open issue for that - https://github.com/commonsmachinery/tinyxmp/issues/2).

But this seems to work, so I think it's a step forward to merge it. Thanks.