### PR TITLE
Adds Exif and PNG Info to all scripts

### DIFF
--- a/optimizedSD/img2img_gradio.py
+++ b/optimizedSD/img2img_gradio.py
@@ -226,7 +226,7 @@ def generate(
                         target_path = os.path.join(sample_path, "seed_" + str(seed) + "_" +
                                                    f"{base_count:05}.{img_format}")
                         info, exif = create_exif_info(img, seed, prompt, ddim_steps, sampler, scale,
-                                                      full_precision, batch_size, i, "text2img_gradio.py")
+                                                      full_precision, batch_size, i, "img2img_gradio.py")
                         img.save(target_path, pnginfo=info, exif=exif)
                         seeds += str(seed) + ","
                         seed += 1

--- a/optimizedSD/img2img_gradio.py
+++ b/optimizedSD/img2img_gradio.py
@@ -21,7 +21,8 @@ from contextlib import nullcontext
 from ldm.util import instantiate_from_config
 from transformers import logging
 import pandas as pd
-from optimUtils import split_weighted_subprompts, logger
+from optimUtils import split_weighted_subprompts, logger, create_exif_info
+
 logging.set_verbosity_error()
 import mimetypes
 mimetypes.init()
@@ -221,9 +222,12 @@ def generate(
                         x_sample = torch.clamp((x_samples_ddim + 1.0) / 2.0, min=0.0, max=1.0)
                         all_samples.append(x_sample.to("cpu"))
                         x_sample = 255.0 * rearrange(x_sample[0].cpu().numpy(), "c h w -> h w c")
-                        Image.fromarray(x_sample.astype(np.uint8)).save(
-                            os.path.join(sample_path, "seed_" + str(seed) + "_" + f"{base_count:05}.{img_format}")
-                        )
+                        img = Image.fromarray(x_sample.astype(np.uint8))
+                        target_path = os.path.join(sample_path, "seed_" + str(seed) + "_" +
+                                                   f"{base_count:05}.{img_format}")
+                        info, exif = create_exif_info(img, seed, prompt, ddim_steps, sampler, scale,
+                                                      full_precision, batch_size, i, "text2img_gradio.py")
+                        img.save(target_path, pnginfo=info, exif=exif)
                         seeds += str(seed) + ","
                         seed += 1
                         base_count += 1

--- a/optimizedSD/inpaint_gradio.py
+++ b/optimizedSD/inpaint_gradio.py
@@ -224,7 +224,7 @@ def generate(
                         target_path = os.path.join(sample_path, "seed_" + str(seed) + "_" +
                                                    f"{base_count:05}.{img_format}")
                         info, exif = create_exif_info(img, seed, prompt, ddim_steps, sampler, scale,
-                                                      full_precision, batch_size, i, "text2img_gradio.py")
+                                                      full_precision, batch_size, i, "inpaint_gradio.py")
                         img.save(target_path, pnginfo=info, exif=exif)
                         seeds += str(seed) + ","
                         seed += 1

--- a/optimizedSD/optimized_txt2img.py
+++ b/optimizedSD/optimized_txt2img.py
@@ -13,7 +13,7 @@ from pytorch_lightning import seed_everything
 from torch import autocast
 from contextlib import contextmanager, nullcontext
 from ldm.util import instantiate_from_config
-from optimUtils import split_weighted_subprompts, logger
+from optimUtils import split_weighted_subprompts, logger, create_exif_info
 from transformers import logging
 # from samplers import CompVisDenoiser
 logging.set_verbosity_error()
@@ -237,7 +237,8 @@ if not opt.from_file:
 else:
     print(f"reading prompts from {opt.from_file}")
     with open(opt.from_file, "r") as f:
-        data = f.read().splitlines()
+        prompt = f.read()
+        data = prompt.splitlines()
         data = batch_size * list(data)
         data = list(chunk(sorted(data), batch_size))
 
@@ -309,8 +310,12 @@ with torch.no_grad():
                     x_samples_ddim = modelFS.decode_first_stage(samples_ddim[i].unsqueeze(0))
                     x_sample = torch.clamp((x_samples_ddim + 1.0) / 2.0, min=0.0, max=1.0)
                     x_sample = 255.0 * rearrange(x_sample[0].cpu().numpy(), "c h w -> h w c")
-                    Image.fromarray(x_sample.astype(np.uint8)).save(
-                        os.path.join(sample_path, "seed_" + str(opt.seed) + "_" + f"{base_count:05}.{opt.format}")
+                    img = Image.fromarray(x_sample.astype(np.uint8))
+                    info, exif = create_exif_info(img, opt.seed, prompt, opt.ddim_steps, opt.sampler, opt.scale,
+                                                  opt.precision, batch_size, i, "optimized_txt2img.py")
+                    img.save(
+                        os.path.join(sample_path, "seed_" + str(opt.seed) + "_" + f"{base_count:05}.{opt.format}"),
+                        pnginfo=info
                     )
                     seeds += str(opt.seed) + ","
                     opt.seed += 1

--- a/optimizedSD/txt2img_gradio.py
+++ b/optimizedSD/txt2img_gradio.py
@@ -20,7 +20,7 @@ from pytorch_lightning import seed_everything
 from torch import autocast
 from contextlib import nullcontext
 from ldm.util import instantiate_from_config
-from optimUtils import split_weighted_subprompts, logger
+from optimUtils import split_weighted_subprompts, logger, create_exif_info
 from transformers import logging
 logging.set_verbosity_error()
 import mimetypes
@@ -95,7 +95,6 @@ def generate(
     full_precision,
     sampler,
 ):
-
     C = 4
     f = 8
     start_code = None
@@ -178,20 +177,22 @@ def generate(
                         unconditional_conditioning=uc,
                         eta=ddim_eta,
                         x_T=start_code,
-                        sampler = sampler,
+                        sampler=sampler,
                     )
 
                     modelFS.to(device)
                     print("saving images")
                     for i in range(batch_size):
-
                         x_samples_ddim = modelFS.decode_first_stage(samples_ddim[i].unsqueeze(0))
                         x_sample = torch.clamp((x_samples_ddim + 1.0) / 2.0, min=0.0, max=1.0)
                         all_samples.append(x_sample.to("cpu"))
                         x_sample = 255.0 * rearrange(x_sample[0].cpu().numpy(), "c h w -> h w c")
-                        Image.fromarray(x_sample.astype(np.uint8)).save(
-                            os.path.join(sample_path, "seed_" + str(seed) + "_" + f"{base_count:05}.{img_format}")
-                        )
+                        img = Image.fromarray(x_sample.astype(np.uint8))
+                        target_path = os.path.join(sample_path, "seed_" + str(seed) + "_" +
+                                                   f"{base_count:05}.{img_format}")
+                        info, exif = create_exif_info(img, seed, prompt, ddim_steps, sampler, scale,
+                                                      full_precision, batch_size, i, "text2img_gradio.py")
+                        img.save(target_path, pnginfo=info, exif=exif)
                         seeds += str(seed) + ","
                         seed += 1
                         base_count += 1


### PR DESCRIPTION
This Adds Information about the settings as EXIF and/or PNG Info to all scripts

## motivation
See #139 

## why exif and pnginfo

PNGinfo alone is not enough since it will not work on JPEGs, which are supported by the gradio scripts
Also PNGinfo is harder to view, especially on windows machines

EXIF supports both png and jpeg, but is not as nice and tidy as png info, so i decided to use both

## difference to #65 
#65 only adds PNGInfo and locks the file type to pngs
it also only adds exif to the non gradio scripts


## stuff to discuss / workon:

- [ ] only exiff, no PNGInfo
- [ ] make it toggable possibly
- [ ] Fix User Comment Encoding
