### PR TITLE
Use modern method to enable GPU access in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,12 @@ services:
       - ../sd-data:/data
       - ../sd-output:/output
       - sd-cache:/root/.cache
-    runtime: nvidia
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
 volumes:
   sd-cache:


### PR DESCRIPTION
As stated in [the Compose docs](https://docs.docker.com/compose/gpu-support/), `runtime: nvidia` is a legacy method. It didn't even work in my WSL environment.

In this PR the modern method is used, exactly as suggested in the official documentation.