### PR TITLE
Add git to environment.yaml dependencies

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -3,6 +3,7 @@ channels:
   - pytorch
   - defaults
 dependencies:
+  - git
   - python=3.8.5
   - pip=20.3
   - cudatoolkit=11.3


### PR DESCRIPTION
Anaconda couldn't create the environment without this on my Windows machine, this trick was advised [here](https://www.reddit.com/r/deepdream/comments/wv1ccf/miniguide_to_installing_stablediffusion/).