### PR TITLE
Write metadata to a txt file

### DIFF
--- a/optimizedSD/txt2img_gradio.py
+++ b/optimizedSD/txt2img_gradio.py
@@ -24,6 +24,7 @@ from optimUtils import split_weighted_subprompts, logger
 from transformers import logging
 logging.set_verbosity_error()
 import mimetypes
+import glob
 mimetypes.init()
 mimetypes.add_type("application/javascript", ".js")
 
@@ -222,9 +223,10 @@ def generate(
         + "\nSeeds used = "
         + seeds[:-1]
     )
-    
+
     # write the metadata to a file
-    with open(os.path.join(sample_path, "description" + "_" + f"{base_count:05}.txt"), 'w') as f:
+    txt_count = len(glob.glob(sample_path+"/*.txt")) + 1
+    with open(os.path.join(sample_path, "description" + "_" + f"{txt_count:05}.txt"), 'w') as f:
         f.write(prompt)
         f.write("\n--------------")
         f.write("\nddim_steps: "+str(ddim_steps))
@@ -236,13 +238,13 @@ def generate(
         f.write("\nddim_eta: "+str(ddim_eta))
         f.write("\nunet_bs: "+str(unet_bs))
         f.write("\ndevice: "+str(device))
-        f.write("\nseed: "+str(seed))
+        f.write("\nseeds: "+seeds[:-1])
         f.write("\nturbo: "+str(turbo))
         f.write("\nfull_precision: "+str(full_precision))
         f.write("\nsampler: "+str(sampler))
         f.write("\n--------------")
         f.write("\nOutput: \n"+txt)
-    
+
     return Image.fromarray(grid.astype(np.uint8)), txt
 
 

--- a/optimizedSD/txt2img_gradio.py
+++ b/optimizedSD/txt2img_gradio.py
@@ -222,6 +222,27 @@ def generate(
         + "\nSeeds used = "
         + seeds[:-1]
     )
+    
+    # write the metadata to a file
+    with open(os.path.join(sample_path, "description" + "_" + f"{base_count:05}.txt"), 'w') as f:
+        f.write(prompt)
+        f.write("\n--------------")
+        f.write("\nddim_steps: "+str(ddim_steps))
+        f.write("\nn_iter: "+str(n_iter))
+        f.write("\nbatch_size: "+str(batch_size))
+        f.write("\nHeight: "+str(Height))
+        f.write("\nWidth: "+str(Width))
+        f.write("\nscale: "+str(scale))
+        f.write("\nddim_eta: "+str(ddim_eta))
+        f.write("\nunet_bs: "+str(unet_bs))
+        f.write("\ndevice: "+str(device))
+        f.write("\nseed: "+str(seed))
+        f.write("\nturbo: "+str(turbo))
+        f.write("\nfull_precision: "+str(full_precision))
+        f.write("\nsampler: "+str(sampler))
+        f.write("\n--------------")
+        f.write("\nOutput: \n"+txt)
+    
     return Image.fromarray(grid.astype(np.uint8)), txt
 
 


### PR DESCRIPTION
I find it useful to write the metadata from the gradio UI to a text file in the output dir, as I tend to forget what parameters I've used for a prompt.

A sample output:

```
fractal forest, intricate detail
--------------
ddim_steps: 50
n_iter: 1
batch_size: 1
Height: 512
Width: 512
scale: 7.5
ddim_eta: 0
unet_bs: 1
device: cuda
seed: 907564
turbo: False
full_precision: True
sampler: plms
--------------
Output: 
Samples finished in 2.292 minutes and exported to outputs/txt2img-samples\fractal_forest,_intricate_detail
Seeds used = 907563
```