### PR TITLE
Docker image customization and minification

### DIFF
--- a/docker-bootstrap.sh
+++ b/docker-bootstrap.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($HOME/miniconda/bin/conda shell.bash hook)"
-conda activate ldm
+source /venv/bin/activate
+update-ca-certificates --fresh
+export SSL_CERT_DIR=/etc/ssl/certs
 exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - ../sd-data:/data
       - ../sd-output:/output
       - sd-cache:/root/.cache
+    environment:
+      - APP_MAIN_FILE=txt2img_gradio.py
     deploy:
       resources:
         reservations:

--- a/environment.yaml
+++ b/environment.yaml
@@ -8,7 +8,7 @@ dependencies:
   - cudatoolkit=11.3
   - pytorch=1.11.0
   - torchvision=0.12.0
-  - numpy=1.19.2
+  - numpy=1.20.3
   - pip:
     - albumentations==0.4.3
     - opencv-python==4.1.2.30


### PR DESCRIPTION
## Docker image customization and minification

Hello everyone, I made some improvements to Dockerfile and docker-compose, I hope it will be helpful in the community.

### What was improved?

- Reduction in final image size from `10.3GB` to `7.19GB`
- Update `nvidia/cuda` image from `11.3.1-base-ubuntu20.04` to `11.8.0-base-ubuntu22.04`
- Customization of the execution of files from the `optimizedSD` directory
- Update **numpy** from `1.19.2` to `1.20.3`

### How to use execution customization?

- If you need to run another file from the `OptimizedSD` directory,  is possible to modify the default execution, by changing the environment variable  `APP_MAIN_FILE` in `docker-compose.yml` and doing a new build by running:

```bash 
docker-compose up --build
```

- If you don't want to use docker-compose, you can provide the `OPTIMIZED_FILE` argument with the following command.

```bash
docker build --tag newimage --build-arg OPTIMIZED_FILE=optimized_img2img.py .
```

### What was not improved?

- No modifications to the project's source.

### **Wrong:** to ensure that the tests do not have side effects, please remove container and docker images related to the project.

### Ideas to improve build time in the future

- The `venv` could be uploaded to some storage and when building the image download the environment, this will probably be considerably faster than the build step.

- **Positive:** The image does not need to go through several steps to build the environment (compression and decompression, downloading packages)
- **Negative:** I would need to update `venv` whenever new dependencies are added to the project

